### PR TITLE
Doc fix: The Imputer is an Estimator

### DIFF
--- a/docs/ml-features.md
+++ b/docs/ml-features.md
@@ -1429,7 +1429,7 @@ for more details on the API.
 
 ## Imputer
 
-The `Imputer` transformer completes missing values in a dataset, either using the mean or the 
+The `Imputer` estimator completes missing values in a dataset, either using the mean or the 
 median of the columns in which the missing values are located. The input columns should be of
 `DoubleType` or `FloatType`. Currently `Imputer` does not support categorical features and possibly
 creates incorrect values for columns containing categorical features. Imputer can impute custom values 


### PR DESCRIPTION
The imputer is not a `Transformer` but an `Estimator`.

https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/feature/Imputer.scala#L96-L97

## What changes were proposed in this pull request?

Simply fixing the documentation of the Imputer

## How was this patch tested?

manual testing

Please review http://spark.apache.org/contributing.html before opening a pull request.
